### PR TITLE
Basic AppIoT GW Settings

### DIFF
--- a/appiot-gateway.settings
+++ b/appiot-gateway.settings
@@ -1,0 +1,27 @@
+[
+  {
+    "Name": "GatewaySDK",
+    "Settings": [
+      {
+        "Key": "ReportInterval",
+        "Value": 1000,
+        "DataType": "Integer"
+      },
+      {
+        "Key": "EnableQueue",
+        "Value": true,
+        "DataType": "Boolean"
+      },
+      {
+        "Key": "QueueSize",
+        "Value": 1000,
+        "DataType": "Integer"
+      },
+      {
+        "Key": "LogLevel",
+        "Value": "INFO",
+        "DataType": "String"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
GW settings are substantially different from 1.6. From sensation-client settings (ini type of file) to json format configuration (with key/value/datatype).
It's important to provide some basic example alongside this code that will be broadly used